### PR TITLE
[IBS-32,33] CRUD Views for Interviews

### DIFF
--- a/frontend/src/api/staff_api.js
+++ b/frontend/src/api/staff_api.js
@@ -489,38 +489,39 @@ const changeInterview = async (
 ) => {
     let token = sessionStorage.getItem('token');
 
-    let config = {
-        data: {
-            task,
-            set_time,
-            set_group_id,
-            set_length,
-            set_location,
-            set_note,
-            set_cancelled,
-            interview_id,
-            booked,
-            time,
-            date,
-            group_id,
-            length,
-            location,
-            note,
-            cancelled
-        },
+    let data = {
+        task,
+        set_time,
+        set_group_id,
+        set_length,
+        set_location,
+        set_note,
+        set_cancelled,
+        interview_id,
+        booked,
+        time,
+        date,
+        group_id,
+        length,
+        location,
+        note,
+        cancelled
+    };
+
+    const config = {
         headers: { Authorization: `Bearer ${token}` }
     };
 
     // delete all undefined/null fields from config.data
-    config.data = Object.fromEntries(
-        Object.entries(config.data).filter(([key, value]) => value != null)
-    );
+    data = Object.fromEntries(Object.entries(data).filter(([key, value]) => value != null));
+    console.log('[+]');
+    console.log(data);
 
     const role = findRoleInCourse(courseId);
     if (role === 'instructor' || role === 'ta') {
         const url = `${process.env.REACT_APP_API_URL}/${role}/course/${courseId}/interview/change`;
         try {
-            return await axios.put(url, config);
+            return await axios.put(url, data, config);
         } catch (err) {
             return err.response;
         }

--- a/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleFilterFields.jsx
+++ b/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleFilterFields.jsx
@@ -230,7 +230,7 @@ const RescheduleFilterFields = (props) => {
 
                                     setFilterFields({
                                         interview_id: selectedInterviewId,
-                                        booked: true,
+                                        booked: selectedInterviewObj.group_id != null,
                                         time: selectedInterviewObj.start_time,
                                         group_id:
                                             selectedInterviewObj.group_id == null
@@ -294,13 +294,14 @@ const RescheduleFilterFields = (props) => {
                                 <RadioGroup
                                     id="booked-filter-field"
                                     row
-                                    value={filterFields.booked || false}
+                                    value={filterFields.booked}
                                     onChange={(event) =>
                                         setFilterFields((prevState) => {
                                             if (prevState.booked !== event.target.value) {
                                                 return {
                                                     ...prevState,
-                                                    booked: event.target.value
+                                                    booked: event.target.value,
+                                                    force: true
                                                 };
                                             }
                                             return prevState;
@@ -318,6 +319,10 @@ const RescheduleFilterFields = (props) => {
                                         value={false}
                                     />
                                 </RadioGroup>
+                                <Typography>
+                                    <strong>Note</strong>: If interview is booked, notify your
+                                    students that the interview has been changed via other means.
+                                </Typography>
                             </>
                         )}
                         {/* Note, sending only time is sufficient as it covers date as well */}

--- a/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleFilterFields.jsx
+++ b/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleFilterFields.jsx
@@ -19,6 +19,12 @@ import CustomFormLabel from '../../../FlexyMainComponents/forms/custom-elements/
 import CustomTextField from '../../../FlexyMainComponents/forms/custom-elements/CustomTextField';
 import { FilterFieldsContext } from '../../../../contexts/RescheduleContexts/FilterFieldsContext';
 import CustomSelect from '../../../FlexyMainComponents/forms/custom-elements/CustomSelect';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { DesktopDateTimePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import moment from 'moment/moment';
+import { parseISO } from 'date-fns';
+import useSWR from 'swr';
+import StaffApi from '../../../../api/staff_api';
 
 const RescheduleFilterFields = (props) => {
     const { filterFields, setFilterFields } = React.useContext(FilterFieldsContext);
@@ -26,8 +32,7 @@ const RescheduleFilterFields = (props) => {
     const [showFilterInputs, setShowFilterInputs] = React.useState({
         interviewId: false,
         booked: false,
-        time: false,
-        date: false,
+        dateTime: false,
         groupId: false,
         length: false,
         location: false,
@@ -37,6 +42,20 @@ const RescheduleFilterFields = (props) => {
 
     const [locationSelectVal, setLocationSelectVal] = React.useState('Online');
     const [isLocationOnline, setIsLocationOnline] = React.useState(true);
+
+    const [prefillDataId, setPrefillDataId] = React.useState('');
+    const [prefillInterviewsArr, setPrefillInterviewsArr] = React.useState([]);
+
+    const { data, error, isLoading } = useSWR('/interviews/get-all', () =>
+        StaffApi.getAllInterviews(props.courseId, props.taskId).then((res) => res.data)
+    );
+
+    React.useEffect(() => {
+        if (isLoading || error) return;
+        const interviewsArr = data.interviews;
+        setPrefillInterviewsArr(interviewsArr);
+        console.log(data);
+    }, [props.courseId, data, isLoading, error]);
 
     return (
         <Container>
@@ -68,6 +87,7 @@ const RescheduleFilterFields = (props) => {
                                                     interviewId: checked
                                                 }));
                                             }}
+                                            checked={showFilterInputs.interviewId}
                                         />
                                     }
                                     label="Interview ID"
@@ -82,6 +102,7 @@ const RescheduleFilterFields = (props) => {
                                                     booked: checked
                                                 }));
                                             }}
+                                            checked={showFilterInputs.booked}
                                         />
                                     }
                                     label="Booked (Yes/No)"
@@ -93,26 +114,13 @@ const RescheduleFilterFields = (props) => {
                                             onChange={(event, checked) => {
                                                 setShowFilterInputs((prevState) => ({
                                                     ...prevState,
-                                                    time: checked
+                                                    dateTime: checked
                                                 }));
                                             }}
+                                            checked={showFilterInputs.dateTime}
                                         />
                                     }
-                                    label="Time"
-                                />
-                                <FormControlLabel
-                                    control={
-                                        <Checkbox
-                                            disableRipple
-                                            onChange={(event, checked) => {
-                                                setShowFilterInputs((prevState) => ({
-                                                    ...prevState,
-                                                    date: checked
-                                                }));
-                                            }}
-                                        />
-                                    }
-                                    label="Date"
+                                    label="Date & Time"
                                 />
                             </Stack>
                             <Stack direction="row">
@@ -126,6 +134,7 @@ const RescheduleFilterFields = (props) => {
                                                     groupId: checked
                                                 }));
                                             }}
+                                            checked={showFilterInputs.groupId}
                                         />
                                     }
                                     label="Group ID"
@@ -140,6 +149,7 @@ const RescheduleFilterFields = (props) => {
                                                     length: checked
                                                 }));
                                             }}
+                                            checked={showFilterInputs.length}
                                         />
                                     }
                                     label="Length"
@@ -154,6 +164,7 @@ const RescheduleFilterFields = (props) => {
                                                     location: checked
                                                 }));
                                             }}
+                                            checked={showFilterInputs.location}
                                         />
                                     }
                                     label="Location"
@@ -168,6 +179,7 @@ const RescheduleFilterFields = (props) => {
                                                     note: checked
                                                 }));
                                             }}
+                                            checked={showFilterInputs.note}
                                         />
                                     }
                                     label="Note"
@@ -182,6 +194,7 @@ const RescheduleFilterFields = (props) => {
                                                     cancelled: checked
                                                 }));
                                             }}
+                                            checked={showFilterInputs.cancelled}
                                         />
                                     }
                                     label="Cancelled (Yes/No)"
@@ -190,6 +203,69 @@ const RescheduleFilterFields = (props) => {
                         </FormGroup>
                     </Box>
                     <Box sx={{ mt: 0 }}>
+                        <CustomFormLabel htmlFor="prefill-filter-data-label" sx={{ mb: 0 }}>
+                            Prefill data using existing interview
+                        </CustomFormLabel>
+                        <CustomSelect
+                            labelId="prefill-filter-data-label"
+                            id="prefill-filter-data"
+                            value={prefillDataId}
+                            onChange={(event, newVal) => {
+                                const selectedInterviewId = event.target.value;
+                                setPrefillDataId(selectedInterviewId);
+                                const selectedInterviewObj = prefillInterviewsArr.find(
+                                    (interview) => interview.interview_id === selectedInterviewId
+                                );
+                                if (selectedInterviewObj) {
+                                    setShowFilterInputs({
+                                        interviewId: true,
+                                        booked: true,
+                                        dateTime: true,
+                                        groupId: true,
+                                        length: true,
+                                        location: true,
+                                        note: true,
+                                        cancelled: true
+                                    });
+
+                                    setFilterFields({
+                                        interview_id: selectedInterviewId,
+                                        booked: true,
+                                        time: selectedInterviewObj.start_time,
+                                        group_id:
+                                            selectedInterviewObj.group_id == null
+                                                ? ''
+                                                : selectedInterviewObj.group_id,
+                                        length: selectedInterviewObj.length,
+                                        location: selectedInterviewObj.location,
+                                        note:
+                                            selectedInterviewObj.note == null
+                                                ? ''
+                                                : selectedInterviewObj.note,
+                                        cancelled: false
+                                    });
+                                }
+                            }}
+                            displayEmpty
+                            size="small"
+                            fullWidth
+                            sx={{ mt: 2 }}
+                        >
+                            <MenuItem disabled value="">
+                                <em>Select interview</em>
+                            </MenuItem>
+                            {prefillInterviewsArr.map((interview, idx) => {
+                                const startTime = interview.start_time;
+                                const timeFormatted =
+                                    moment(startTime).format('MM/DD/YYYY, h:mm A');
+                                return (
+                                    <MenuItem
+                                        value={interview.interview_id}
+                                        key={`interview-prefill-${idx}`}
+                                    >{`${interview.location} at ${timeFormatted}`}</MenuItem>
+                                );
+                            })}
+                        </CustomSelect>
                         {showFilterInputs.interviewId && (
                             <>
                                 <CustomFormLabel htmlFor="interview-id-input" sx={{ mb: 0 }}>
@@ -198,11 +274,11 @@ const RescheduleFilterFields = (props) => {
                                 <CustomTextField
                                     id="interview-id-input"
                                     margin="normal"
-                                    value={filterFields.interviewId}
+                                    value={filterFields.interview_id}
                                     onChange={(event) => {
                                         setFilterFields((prevState) => ({
                                             ...prevState,
-                                            interviewId: event.target.value
+                                            interview_id: event.target.value
                                         }));
                                     }}
                                     size="small"
@@ -244,7 +320,37 @@ const RescheduleFilterFields = (props) => {
                                 </RadioGroup>
                             </>
                         )}
-                        {/* TODO: Implement time and date inputs */}
+                        {/* Note, sending only time is sufficient as it covers date as well */}
+                        {showFilterInputs.dateTime && (
+                            <>
+                                <CustomFormLabel htmlFor="dateTime-filter-field" sx={{ mb: 0 }}>
+                                    Date & Time
+                                </CustomFormLabel>
+                                <LocalizationProvider dateAdapter={AdapterDateFns}>
+                                    <DesktopDateTimePicker
+                                        placeholder="Date & Time"
+                                        onChange={(value) => {
+                                            // value is Date object
+                                            const dateToTimeString =
+                                                moment(value).format('YYYY-MM-DD HH:mm:ss');
+                                            setFilterFields((prevState) => {
+                                                if (prevState.time !== dateToTimeString) {
+                                                    return { ...prevState, time: dateToTimeString };
+                                                }
+                                                return prevState;
+                                            });
+                                        }}
+                                        slotProps={{
+                                            textField: {
+                                                variant: 'outlined',
+                                                size: 'small'
+                                            }
+                                        }}
+                                        value={parseISO(filterFields.time)}
+                                    />
+                                </LocalizationProvider>
+                            </>
+                        )}
                         {showFilterInputs.groupId && (
                             <>
                                 <CustomFormLabel htmlFor="group-id-filter-field" sx={{ mb: 0 }}>

--- a/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleInterview.jsx
+++ b/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleInterview.jsx
@@ -11,30 +11,80 @@ import {
     UpdatedFieldsProvider,
     UpdatedFieldsContext
 } from '../../../../contexts/RescheduleContexts/UpdatedFieldsContext';
-import { Button } from '@mui/material';
+import { Box, Button, Container } from '@mui/material';
+import { toast } from 'react-toastify';
+import StaffApi from '../../../../api/staff_api';
+import { useNavigate } from 'react-router-dom';
 
 const RescheduleInterview = (props) => {
-    const { filterInputFieldsObj, setFilterInputFieldsObj } = React.useContext(FilterFieldsContext);
-    const { updatedInfo, setUpdatedInfo } = React.useContext(UpdatedFieldsContext);
-
-    // change interview
-    const rescheduleInterview = (task, toNewFieldsObj, filterInputFieldsObj) => {
-        // TaApi.changeInterview(course_id, task).then((res) => {});
-    };
-
     return (
         <FilterFieldsProvider>
             <UpdatedFieldsProvider>
-                <Grid container columns={12}>
-                    <Grid xs={6}>
-                        <RescheduleFilterFields courseId={props.courseId} taskId={props.taskId} />
-                    </Grid>
-                    <Grid xs={6}>
-                        <RescheduleUpdatedFields courseId={props.courseId} taskId={props.taskId} />
-                    </Grid>
+                <RescheduleInterviewContent {...props} />
+            </UpdatedFieldsProvider>
+        </FilterFieldsProvider>
+    );
+};
+
+const RescheduleInterviewContent = (props) => {
+    const navigate = useNavigate();
+    const { filterFields, setFilterFields } = React.useContext(FilterFieldsContext);
+    const { updatedFields, setUpdatedFields } = React.useContext(UpdatedFieldsContext);
+
+    // change interview
+    const rescheduleInterview = (task, toNewFieldsObj, filterInputFieldsObj) => {
+        // remove keys with null or empty string values
+        let cleanedFilterFields = Object.fromEntries(
+            Object.entries(filterInputFieldsObj).filter(
+                ([key, value]) => value != null && value !== ''
+            )
+        );
+
+        let cleanedUpdatedFields = Object.fromEntries(
+            Object.entries(toNewFieldsObj).filter(([key, value]) => value != null && value !== '')
+        );
+        // DEV message
+        // toast.success('Everything is ok', { theme: 'colored' });
+        // console.log('=======================');
+        // console.log(cleanedFilterFields);
+        // console.log(cleanedUpdatedFields);
+        StaffApi.changeInterview(
+            props.courseId,
+            task,
+            cleanedUpdatedFields,
+            cleanedFilterFields
+        ).then((res) => {
+            if (!res || !('status' in res)) {
+                toast.error('Unknown error', { theme: 'colored' });
+                navigate('/login');
+            } else if (res.status === 200) {
+                toast.success(res.data.message, { theme: 'colored' });
+            } else if (res.status === 400 || res.status === 409) {
+                toast.warn(res.data.message, { theme: 'colored' });
+            } else if (res.status === 401 || res.status === 403) {
+                console.log(res);
+                toast.warn('You need to login again', { theme: 'colored' });
+                navigate('/login');
+            } else {
+                toast.error('Unknown error', { theme: 'colored' });
+                navigate('/login');
+            }
+        });
+    };
+
+    return (
+        <Grid container columns={12}>
+            <Grid xs={6}>
+                <RescheduleFilterFields courseId={props.courseId} taskId={props.taskId} />
+            </Grid>
+            <Grid xs={6}>
+                <RescheduleUpdatedFields courseId={props.courseId} taskId={props.taskId} />
+                <Box display="flex" justifyContent="flex-end" alignItems="flex-end" sx={{ mr: 4 }}>
                     <Button
                         onClick={() => {
-                            rescheduleInterview(props.taskId, updatedInfo, filterInputFieldsObj);
+                            console.log(updatedFields);
+                            console.log(filterFields);
+                            rescheduleInterview(props.taskId, updatedFields, filterFields);
                         }}
                         variant="contained"
                         size="large"
@@ -42,9 +92,9 @@ const RescheduleInterview = (props) => {
                     >
                         Confirm Change
                     </Button>
-                </Grid>
-            </UpdatedFieldsProvider>
-        </FilterFieldsProvider>
+                </Box>
+            </Grid>
+        </Grid>
     );
 };
 

--- a/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleInterview.jsx
+++ b/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleInterview.jsx
@@ -15,12 +15,18 @@ import { Box, Button, Container } from '@mui/material';
 import { toast } from 'react-toastify';
 import StaffApi from '../../../../api/staff_api';
 import { useNavigate } from 'react-router-dom';
+import {
+    RefreshInterviewsContext,
+    RefreshInterviewsProvider
+} from '../../../../contexts/RescheduleContexts/RefreshInterviewsContext';
 
 const RescheduleInterview = (props) => {
     return (
         <FilterFieldsProvider>
             <UpdatedFieldsProvider>
-                <RescheduleInterviewContent {...props} />
+                <RefreshInterviewsProvider>
+                    <RescheduleInterviewContent {...props} />
+                </RefreshInterviewsProvider>
             </UpdatedFieldsProvider>
         </FilterFieldsProvider>
     );
@@ -30,6 +36,7 @@ const RescheduleInterviewContent = (props) => {
     const navigate = useNavigate();
     const { filterFields, setFilterFields } = React.useContext(FilterFieldsContext);
     const { updatedFields, setUpdatedFields } = React.useContext(UpdatedFieldsContext);
+    const { refreshInterviews, setRefreshInterviews } = React.useContext(RefreshInterviewsContext);
 
     // change interview
     const rescheduleInterview = (task, toNewFieldsObj, filterInputFieldsObj) => {
@@ -82,9 +89,8 @@ const RescheduleInterviewContent = (props) => {
                 <Box display="flex" justifyContent="flex-end" alignItems="flex-end" sx={{ mr: 4 }}>
                     <Button
                         onClick={() => {
-                            console.log(updatedFields);
-                            console.log(filterFields);
                             rescheduleInterview(props.taskId, updatedFields, filterFields);
+                            setRefreshInterviews(true);
                         }}
                         variant="contained"
                         size="large"

--- a/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleUpdatedFields.jsx
+++ b/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleUpdatedFields.jsx
@@ -22,6 +22,7 @@ import CustomTextField from '../../../FlexyMainComponents/forms/custom-elements/
 import CustomSelect from '../../../FlexyMainComponents/forms/custom-elements/CustomSelect';
 import CustomFormLabel from '../../../FlexyMainComponents/forms/custom-elements/CustomFormLabel';
 import { UpdatedFieldsContext } from '../../../../contexts/RescheduleContexts/UpdatedFieldsContext';
+import { FilterFieldsContext } from '../../../../contexts/RescheduleContexts/FilterFieldsContext';
 
 const EditCardItem = ({ title, oldDesc, newInput }) => {
     return (
@@ -48,18 +49,7 @@ const EditCardItem = ({ title, oldDesc, newInput }) => {
 const RescheduleUpdatedFields = (props) => {
     // for backend query to changeInterview API
     const { updatedFields, setUpdatedFields } = React.useContext(UpdatedFieldsContext);
-
-    const [filterInputFieldsObj, setFilterInputFieldsObj] = React.useState({
-        interview_id: null,
-        booked: null,
-        time: null,
-        date: null,
-        group_id: null,
-        length: null,
-        location: null,
-        note: null,
-        cancelled: null
-    });
+    const { filterFields } = React.useContext(FilterFieldsContext);
 
     // for change interview's new location select
     const [isNewLocOnline, setIsNewLocOnline] = React.useState(true);
@@ -244,7 +234,52 @@ const RescheduleUpdatedFields = (props) => {
                             }
                         />
                         {/*TODO: Implement set_group_id input*/}
-                        {/*TODO: Implement set_note input*/}
+                        <EditCardItem
+                            title="Set new group ID"
+                            oldDesc={undefined}
+                            newInput={
+                                <CustomTextField
+                                    id="group-id-update-field"
+                                    margin="normal"
+                                    value={updatedFields.group_id}
+                                    onChange={(event) => {
+                                        setUpdatedFields((prevState) => ({
+                                            ...prevState,
+                                            group_id: event.target.value
+                                        }));
+                                    }}
+                                    size="small"
+                                    variant="outlined"
+                                    sx={{ mt: 0 }}
+                                />
+                            }
+                        />
+                        <EditCardItem
+                            title="New Note"
+                            oldDesc={undefined}
+                            newInput={
+                                <CustomTextField
+                                    id="note-update-field"
+                                    placeholder="Write New Note"
+                                    multiline
+                                    rows={4}
+                                    variant="outlined"
+                                    value={updatedFields.note}
+                                    onChange={(event) =>
+                                        setUpdatedFields((prevState) => {
+                                            if (prevState.set_note !== event.target.value) {
+                                                return {
+                                                    ...prevState,
+                                                    set_note: event.target.value
+                                                };
+                                            }
+                                            return prevState;
+                                        })
+                                    }
+                                    sx={{ width: 500 }}
+                                />
+                            }
+                        />
                     </Box>
                 </CardContent>
             </Card>

--- a/frontend/src/components/Page/Staff/InterviewPage.jsx
+++ b/frontend/src/components/Page/Staff/InterviewPage.jsx
@@ -22,8 +22,20 @@ import RescheduleInterview from '../../General/InterviewComponents/RescheduleInt
 import ScheduleInterview from '../../General/InterviewComponents/ScheduleInterview';
 import FlexyTabs from '../../General/FlexyTabs/FlexyTabs';
 import UpcomingInterviews from '../../General/UpcomingInterviews/UpcomingInterviews';
+import {
+    RefreshInterviewsContext,
+    RefreshInterviewsProvider
+} from '../../../contexts/RescheduleContexts/RefreshInterviewsContext';
 
-let InterviewPage = () => {
+const InterviewPage = () => {
+    return (
+        <RefreshInterviewsProvider>
+            <InterviewPageMain />
+        </RefreshInterviewsProvider>
+    );
+};
+
+const InterviewPageMain = () => {
     const navigate = useNavigate();
 
     const { course_id, task } = useParams();
@@ -44,6 +56,10 @@ let InterviewPage = () => {
 
     const [open, setOpen] = useState(false);
     const [version, setVersion] = useState(0); // data is refreshed if version is changed
+
+    // Refresh interviews context
+    // TODO: Fix such that on button click for change interview, data is refreshed on calendar
+    const { refreshInterviews, setRefreshInterviews } = React.useContext(RefreshInterviewsContext);
 
     useEffect(() => {
         StaffApi.getAllInterviews(course_id, task).then((response) => {
@@ -103,8 +119,9 @@ let InterviewPage = () => {
             }
 
             setCalendarData(temp_data);
+            setRefreshInterviews(false);
         });
-    }, [course_id, task, version, navigate]);
+    }, [course_id, task, version, navigate, refreshInterviews]);
 
     // the cancel interview function
     const delete_interview = (task, id) => {

--- a/frontend/src/contexts/RescheduleContexts/RefreshInterviewsContext.jsx
+++ b/frontend/src/contexts/RescheduleContexts/RefreshInterviewsContext.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const RefreshInterviewsContext = React.createContext({
+    refreshInterviews: false,
+    setRefreshInterviews: () => {}
+});
+
+const RefreshInterviewsProvider = ({ children }) => {
+    const [refreshInterviews, setRefreshInterviews] = React.useState(false);
+
+    return (
+        <RefreshInterviewsContext.Provider value={{ refreshInterviews, setRefreshInterviews }}>
+            {children}
+        </RefreshInterviewsContext.Provider>
+    );
+};
+
+export { RefreshInterviewsContext, RefreshInterviewsProvider };


### PR DESCRIPTION
## Overview

### Initial Notes
- The naming of this branch should not be misunderstood.
  - In the beginning, the branch was supposed to handle all CRUD views related to interviews page for TAs.
  - However, as time went on, this branch turned into handling all CRUD views relating to interviews page that is shared between both TAs and instructors alike.

## General Overview
- This remakes the entire `InterviewPage` component which handles views for all interview-related views for instructors and TAs.
- You can **schedule**, **delete**, **re-schedule**, and **view** interviews as the roles mentioned above.
- Viewing interviews (last tab) was mainly done on [[IBS-35] Branch](https://github.com/DakshChan/IBS/pull/33).
- The ability to schedule and delete interviews can be interacted with on the first tab.
- The second tab is in charge of re-scheduling existing interviews via filter options and updated information section.
  - There is a feature which allows pre-filling of existing interviews information via drop-down for changing individual interviews quickly without having to reference back to the calendar in the first tab.

## Example: Re-scheduling interviews
As seen, if one re-schedules an interview, they can see the updated change in either `Schedule/Delete Interviews` tab or `Upcoming Interviews` tab without having to reload the page.

![reschedule_interviews_ta_view](https://github.com/DakshChan/IBS/assets/47423409/a10f80b3-f22e-4bd4-ad65-fee7041c27f7)
