### PR TITLE
Interviews Page (Bug Fixes)

### DIFF
--- a/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleFilterFields.jsx
+++ b/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleFilterFields.jsx
@@ -62,13 +62,22 @@ const RescheduleFilterFields = (props) => {
                 <CardContent sx={{ pb: 0 }}>
                     <Box>
                         <Grid container spacing={0}>
-                            <Grid xs={6}>
+                            <Grid xs={12}>
                                 <Typography variant="h4" sx={{ mt: 0.9 }}>
                                     Filter Fields
                                 </Typography>
-                                <Typography variant="subtitle1" sx={{ mb: 2 }}>
+                                <Typography variant="subtitle1">
                                     Specify which interviews you'd like to reschedule with updated
-                                    information (on right card).
+                                    information (on right-hand side).
+                                </Typography>
+                                <Typography variant="subtitle1">
+                                    <strong>Note</strong>: This side is for specifying the
+                                    "previous" (old) interview details. The right-side pane is for
+                                    specifying the new value(s) that the (filtered) interviews would
+                                    take on.
+                                </Typography>
+                                <Typography variant="subtitle1" sx={{ mb: 2, mt: 1 }}>
+                                    Do <em>not</em> write the new information on this side.
                                 </Typography>
                             </Grid>
                         </Grid>
@@ -354,9 +363,14 @@ const RescheduleFilterFields = (props) => {
                                             textField: {
                                                 variant: 'outlined',
                                                 size: 'small'
-                                            }
+                                            },
+                                            actionBar: { actions: ['today'] }
                                         }}
-                                        value={filterFields.time ? parseISO(filterFields.time) : ''}
+                                        value={
+                                            filterFields.time != null
+                                                ? parseISO(filterFields.time)
+                                                : new Date()
+                                        }
                                     />
                                 </LocalizationProvider>
                             </>

--- a/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleUpdatedFields.jsx
+++ b/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleUpdatedFields.jsx
@@ -277,8 +277,12 @@ const RescheduleUpdatedFields = (props) => {
                                     multiline
                                     rows={4}
                                     variant="outlined"
-                                    value={updatedFields.note == null ? '' : updatedFields.note}
-                                    onChange={(event) =>
+                                    value={
+                                        updatedFields.set_note == null ? '' : updatedFields.set_note
+                                    }
+                                    onChange={(event) => {
+                                        console.log(event.target.value);
+                                        console.log(updatedFields.note == null);
                                         setUpdatedFields((prevState) => {
                                             if (prevState.set_note !== event.target.value) {
                                                 return {
@@ -287,8 +291,8 @@ const RescheduleUpdatedFields = (props) => {
                                                 };
                                             }
                                             return prevState;
-                                        })
-                                    }
+                                        });
+                                    }}
                                     sx={{ width: 500 }}
                                 />
                             }

--- a/frontend/src/components/General/UpcomingInterviews/InterviewsTimeline.jsx
+++ b/frontend/src/components/General/UpcomingInterviews/InterviewsTimeline.jsx
@@ -37,10 +37,10 @@ const InterviewsTimeline = (props) => {
                 const isOnline = interviewObj.location === 'Online';
 
                 const startTimeConversion = moment(interviewObj.start_time).format(
-                    'MMMM Do YYY, h:mm a'
+                    'MMMM Do YYYY, h:mm a'
                 );
                 const endTimeConversion = moment(interviewObj.end_time).format(
-                    'MMMM Do YYY, h:mm a'
+                    'MMMM Do YYYY, h:mm a'
                 );
 
                 const gridStyling = () => (


### PR DESCRIPTION
## Overview

- Fixed the "Upcoming Interviews" section of interviews page not displaying the date correctly.
- Added "Today" button to date picker on filter fields for "Re-schedule Interviews" section.
- Write description/note for what filter fields represent when re-scheduling an interview.