### PR TITLE
Admin Bug Fixes - Fix interview page bugs

### DIFF
--- a/frontend/src/components/General/InterviewCalendar/InterviewCalendar.jsx
+++ b/frontend/src/components/General/InterviewCalendar/InterviewCalendar.jsx
@@ -14,11 +14,15 @@ const localizer = momentLocalizer(moment);
 
 /**
  * Calendar component for interview booking
+ * @param events Default events to prefill calendar with
+ * @param eventClickHandler Event handler for clicking on events
+ * @param selectSlotHandler Event handler for clicking on days (be it eventful or not)
+ * @param width Width of calendar
  * @param props see below PropTypes
  * @returns {JSX.Element}
  * @constructor
  */
-const InterviewCalendar = (props) => {
+const InterviewCalendar = ({ events, eventClickHandler, selectSlotHandler, width, ...props }) => {
     const eventColors = (event) => {
         if (event.color) {
             return { className: `event-${event.color}` };
@@ -27,18 +31,21 @@ const InterviewCalendar = (props) => {
     };
 
     return (
-        <Card sx={{ width: props.width }}>
+        <Card sx={{ width: width }}>
             <CardContent>
                 <Calendar
                     selectable
-                    events={props.events}
+                    events={events}
                     defaultView="month"
                     scrollToTime={new Date(1970, 1, 1, 6)}
                     defaultDate={new Date()}
                     localizer={localizer}
-                    style={{ height: 'calc(100vh - 350px)', width: props.width - 60 }}
-                    onSelectEvent={props.eventClickHandler}
-                    onSelectSlot={props.selectSlotHandler}
+                    style={{
+                        height: 'calc(100vh - 350px)',
+                        width: typeof width === 'number' ? width - 60 : `calc(${width}-60px)`
+                    }}
+                    onSelectEvent={eventClickHandler}
+                    onSelectSlot={selectSlotHandler}
                     eventPropGetter={(event) => eventColors(event)}
                     {...props}
                 />
@@ -48,14 +55,10 @@ const InterviewCalendar = (props) => {
 };
 
 InterviewCalendar.propTypes = {
-    // Default events to prefill calendar with
-    events: PropTypes.array,
-    // Event handler for clicking on events
-    eventClickHandler: PropTypes.func,
-    // Event handler for clicking on days (be it eventful or not)
-    selectSlotHandler: PropTypes.func,
-    // Width of calendar
-    width: PropTypes.number
+    events: PropTypes.array.isRequired,
+    eventClickHandler: PropTypes.func.isRequired,
+    selectSlotHandler: PropTypes.func.isRequired,
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
 };
 
 export default InterviewCalendar;

--- a/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleUpdatedFields.jsx
+++ b/frontend/src/components/General/InterviewComponents/RescheduleInterview/RescheduleUpdatedFields.jsx
@@ -53,7 +53,7 @@ const RescheduleUpdatedFields = (props) => {
 
     // for change interview's new location select
     const [isNewLocOnline, setIsNewLocOnline] = React.useState(true);
-    const [newLocSelectVal, setNewLocSelectVal] = React.useState('Online');
+    const [newLocSelectVal, setNewLocSelectVal] = React.useState('');
 
     return (
         <Container>
@@ -188,7 +188,8 @@ const RescheduleUpdatedFields = (props) => {
                                                 setUpdatedFields((prevState) => {
                                                     if (
                                                         prevState.set_location !==
-                                                        event.target.value
+                                                            event.target.value ||
+                                                        event.target.value !== ''
                                                     ) {
                                                         return {
                                                             ...prevState,
@@ -202,8 +203,12 @@ const RescheduleUpdatedFields = (props) => {
                                             }
                                         }}
                                         fullWidth
+                                        displayEmpty
                                         size="small"
                                     >
+                                        <MenuItem value="" disabled>
+                                            <em>Leave default or choose option</em>
+                                        </MenuItem>
                                         <MenuItem value="In-Person">In-Person</MenuItem>
                                         <MenuItem value="Online">Online</MenuItem>
                                     </CustomSelect>

--- a/frontend/src/components/General/InterviewComponents/ScheduleInterview.jsx
+++ b/frontend/src/components/General/InterviewComponents/ScheduleInterview.jsx
@@ -132,7 +132,6 @@ const ScheduleInterview = (props) => {
                                     setSelectVal(event.target.value);
                                     if (event.target.value === 'Online') {
                                         setIsOnline(true);
-                                        setEnteredLocation(event.target.value);
                                     } else {
                                         setIsOnline(false);
                                     }
@@ -165,7 +164,15 @@ const ScheduleInterview = (props) => {
                                 sx={{ mt: 3 }}
                                 size="large"
                                 onClick={() => {
-                                    schedule_interview(enteredTime, enteredLength, enteredLocation);
+                                    if (enteredLocation === '' && isOnline === true) {
+                                        schedule_interview(enteredTime, enteredLength, 'Online');
+                                        return;
+                                    } else
+                                        schedule_interview(
+                                            enteredTime,
+                                            enteredLength,
+                                            enteredLocation
+                                        );
                                 }}
                             >
                                 Schedule

--- a/frontend/src/components/Page/Staff/InterviewPage.jsx
+++ b/frontend/src/components/Page/Staff/InterviewPage.jsx
@@ -28,6 +28,7 @@ import {
 } from '../../../contexts/RescheduleContexts/RefreshInterviewsContext';
 import PreviousPageButton from '../../General/PreviousPageButton/PreviousPageButton';
 import PageContainer from '../../FlexyMainComponents/container/PageContainer';
+import ConfirmDialog from '../../General/DeleteConfirmation';
 
 const InterviewPage = () => {
     return (
@@ -58,8 +59,14 @@ const InterviewPageMain = () => {
     const [selectedNote, setSelectedNote] = useState('');
     const [selectedCancelled, setSelectedCancelled] = useState('');
 
+    // for opening/closing interview cards when selected from interview calendar
     const [open, setOpen] = useState(false);
+    // reference to selected interview card
     const selectedInterviewCard = useRef(null);
+
+    // confirm dialog for deleting selected interview
+    const [confirmDeleteInterview, setConfirmDeleteInterview] = useState(false);
+
     const [version, setVersion] = useState(0); // data is refreshed if version is changed
 
     // Refresh interviews context
@@ -325,9 +332,19 @@ const InterviewPageMain = () => {
                                                         desc={<pre>{selectedUsername}</pre>}
                                                     />
                                                 )}
+                                                <ConfirmDialog
+                                                    open={confirmDeleteInterview}
+                                                    setOpen={setConfirmDeleteInterview}
+                                                    onConfirm={() => {
+                                                        delete_interview(task, selectedId);
+                                                    }}
+                                                >
+                                                    Are you sure you want to delete the selected
+                                                    interview?
+                                                </ConfirmDialog>
                                                 <Button
                                                     onClick={() => {
-                                                        delete_interview(task, selectedId);
+                                                        setConfirmDeleteInterview(true);
                                                     }}
                                                     variant="contained"
                                                     size="large"

--- a/frontend/src/components/Page/Staff/InterviewPage.jsx
+++ b/frontend/src/components/Page/Staff/InterviewPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import moment from 'moment';
@@ -59,6 +59,7 @@ const InterviewPageMain = () => {
     const [selectedCancelled, setSelectedCancelled] = useState('');
 
     const [open, setOpen] = useState(false);
+    const selectedInterviewCard = useRef(null);
     const [version, setVersion] = useState(0); // data is refreshed if version is changed
 
     // Refresh interviews context
@@ -125,6 +126,10 @@ const InterviewPageMain = () => {
             setRefreshInterviews(false);
         });
     }, [course_id, task, version, navigate, refreshInterviews]);
+
+    useEffect(() => {
+        selectedInterviewCard.current.scrollIntoView(false);
+    }, [open]);
 
     // the cancel interview function
     const delete_interview = (task, id) => {
@@ -213,12 +218,12 @@ const InterviewPageMain = () => {
                     <Grid
                         container
                         spacing={2}
-                        direction="row"
+                        direction="column"
                         alignItems="center"
                         justifyContent="center"
                         columns={12}
                     >
-                        <Grid xs={6}>
+                        <Grid xs={12}>
                             <Container>
                                 <InterviewCalendar
                                     events={calendarData}
@@ -238,14 +243,14 @@ const InterviewPageMain = () => {
                                         setOpen(true);
                                     }}
                                     selectSlotHandler={(slotInfo) => setOpen(false)}
-                                    width={800}
+                                    width="60vw"
                                 />
                             </Container>
                         </Grid>
-                        <Grid xs>
+                        <Grid xs={12} ref={selectedInterviewCard}>
                             {open && (
                                 <Container>
-                                    <Card sx={{ pb: 0, mb: 4, width: '35vw' }}>
+                                    <Card sx={{ pb: 0, mb: 4, width: '60vw' }}>
                                         <CardContent sx={{ pb: 0 }}>
                                             <Box>
                                                 <Grid container spacing={0}>
@@ -326,6 +331,7 @@ const InterviewPageMain = () => {
                                                     }}
                                                     variant="contained"
                                                     size="large"
+                                                    color="error"
                                                     style={{ minWidth: 120, marginTop: 3 }}
                                                 >
                                                     Delete


### PR DESCRIPTION
## Overview
- Center the interview calendar and selected interview card on "Schedule/Delete Interviews" tab.
  - When interview from the calendar is selected, the page will auto-scroll to bottom of page showing the interview card information.
- There was an issue where switching between "In-Person" and "Online" states for scheduling interviews would result in "Enter Room" having value of "Online". -- Fixed
- Upon clicking "Delete" button on selected interview card, show a dialog asking for confirmation to delete interview.
- Display a blank menu item (by default) in "Reschedule Interviews" tab so that the user has choice of ommitting new location information for rescheduling interviews.